### PR TITLE
chore: bump version to 1.8.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-nitro-module",
-    "version": "1.7.4",
+    "version": "1.8.0",
     "description": "A CLI tool that simplifies creating React Native modules powered by Nitro Modules.",
     "private": false,
     "type": "module",


### PR DESCRIPTION
Updated the version of the create-nitro-module package from 1.7.4 to 1.8.0 to reflect recent changes and improvements.