### PR TITLE
chore(e2e): remove commented-out Java setup steps from e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,22 +64,6 @@ jobs:
                   ${{ matrix.pm }} run build
                   node post-script.js
 
-            # - name: Setup Java for Android builds
-            #   uses: actions/setup-java@v4
-            #   with:
-            #       distribution: 'zulu'
-            #       java-version: '17'
-
-            # - name: Make gradlew executable
-            #   working-directory: ${{ env.WORKING_DIR }}/example/android
-            #   run: chmod +x ./gradlew
-
-            # - name: Clean and generate codegen artifacts
-            #   working-directory: ${{ env.WORKING_DIR }}/example/android
-            #   run: |
-            #       ./gradlew clean
-            #       ./gradlew generateCodegenArtifactsFromSchema
-
             - name: Setup Maestro
               uses: ./.github/actions/setup-maestro
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,6 +64,16 @@ jobs:
                   ${{ matrix.pm }} run build
                   node post-script.js
 
+            - name: Setup Java for Android builds
+              uses: actions/setup-java@v4
+              with:
+                  distribution: 'zulu'
+                  java-version: '17'
+                  cache: "gradle"
+
+            - name: Setup Android SDK
+              uses: android-actions/setup-android@v3
+
             - name: Setup Maestro
               uses: ./.github/actions/setup-maestro
 

--- a/.github/workflows/generate-package.yml
+++ b/.github/workflows/generate-package.yml
@@ -5,7 +5,8 @@ on:
         branches: [next]
         paths:
             - 'src/**'
-            - '.github/workflows/test-nitro-cli.yml'
+            - '.github/workflows/**'
+            - '.github/actions/**'
             - 'package.json'
             - 'bun.lock'
             - 'assets/template/**'
@@ -14,7 +15,8 @@ on:
         branches: [main, next]
         paths:
             - 'src/**'
-            - '.github/workflows/test-nitro-cli.yml'
+            - '.github/workflows/**'
+            - '.github/actions/**'
             - 'package.json'
             - 'bun.lock'
             - 'assets/template/**'

--- a/.github/workflows/test-nitro-cli.yml
+++ b/.github/workflows/test-nitro-cli.yml
@@ -188,6 +188,7 @@ jobs:
               with:
                   distribution: 'zulu'
                   java-version: '17'
+                  cache: "gradle"
 
             - name: Make gradlew executable
               working-directory: ${{ env.WORKING_DIR }}/example/android


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed outdated commented steps from the end-to-end workflow configuration. No functional changes were made to the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->