### PR TITLE
chore(e2e): add conditional execution for E2E tests based on previous workflow success

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
     test-android:
+        if: github.event.workflow_run.conclusion == 'success'
         name: Android E2E Test
         runs-on: ubuntu-latest
 
@@ -104,6 +105,7 @@ jobs:
                       ${{ matrix.pm }} android:e2e ${{ env.WORKING_DIR }}/example ${{ matrix.package-type }}
 
     test-ios:
+        if: github.event.workflow_run.conclusion == 'success'
         name: iOS E2E Test
         runs-on: macos-latest
         strategy:

--- a/src/code-snippets/code.js.ts
+++ b/src/code-snippets/code.js.ts
@@ -6,7 +6,7 @@ export const appExampleCode = (
     funcName: string,
     isHybridView: boolean
 ) => `import React from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import {${!isHybridView ? `Text, ` : ' '}View, StyleSheet } from 'react-native';
 import { ${toPascalCase(moduleName)} } from '${finalModuleName}';
 
 function App(): React.JSX.Element {


### PR DESCRIPTION
… workflow success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow for Android and iOS end-to-end tests to only run if previous workflows succeed.

* **Refactor**
  * Improved generated React Native example code to conditionally import components based on view type, resulting in cleaner imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->