### PR TITLE
chore(ci): refactor template android/ios workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -121,6 +121,11 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v5
 
+            - name: Setup Xcode
+              uses: maxim-lobanov/setup-xcode@v1
+              with:
+                  xcode-version: 16.4
+
             - name: Create working directory
               run: mkdir -p ${{ env.WORKING_DIR }}
 

--- a/assets/template/.github/workflows/android-build.yml
+++ b/assets/template/.github/workflows/android-build.yml
@@ -1,5 +1,8 @@
 name: Build Android
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -25,63 +28,52 @@ on:
       - '**/bun.lock'
       - '**/react-native.config.js'
       - '**/nitro.json'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build_new:
-    name: Build Android Example App (new architecture)
+  build:
+    name: Build Android Example App (${{ matrix.arch }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [new, old]
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
 
-      - name: Install npm dependencies (bun)
-        run: bun install
-
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: 17
-          java-package: jdk
-          cache: gradle
-
-      - name: Run Gradle Build for example/android/
-        working-directory: example/android
-        run: ./gradlew assembleDebug --no-daemon --build-cache
-
-      - name: Stop Gradle Daemon
-        working-directory: example/android
-        run: ./gradlew --stop
-
-  build_old:
-    name: Build Android Example App (old architecture)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-
-      - name: Install npm dependencies (bun)
+      - name: Install dependencies (bun)
         run: bun install
 
       - name: Disable new architecture in gradle.properties
+        if: matrix.arch == 'old'
         run: sed -i "s/newArchEnabled=true/newArchEnabled=false/g" example/android/gradle.properties
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
-          java-package: jdk
-          cache: gradle
+          java-version: '17'
+          cache: 'gradle'
 
-      - name: Run Gradle Build for example/android/
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('example/android/**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run Gradle build
         working-directory: example/android
         run: ./gradlew assembleDebug --no-daemon --build-cache
 
-      - name: Stop Gradle Daemon
+      - name: Stop Gradle daemon
         working-directory: example/android
         run: ./gradlew --stop

--- a/assets/template/.github/workflows/ios-build.yml
+++ b/assets/template/.github/workflows/ios-build.yml
@@ -1,5 +1,8 @@
 name: Build iOS
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -33,6 +36,7 @@ on:
       - '**/*.podspec'
       - '**/react-native.config.js'
       - '**/nitro.json'
+  workflow_dispatch:
 
 env:
   USE_CCACHE: 1
@@ -42,9 +46,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_new:
-    name: Build iOS Example App (new architecture)
+  build:
+    name: Build iOS Example App (${{ matrix.arch }})
     runs-on: macOS-15
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [new, old]
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -53,93 +61,47 @@ jobs:
         with:
           xcode-version: 16.4
 
-      - name: Install npm dependencies (bun)
-        run: bun install
-
-      - name: Setup Ruby (bundle)
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7.2
-          bundler-cache: true
-          working-directory: example/ios
-
-      - name: Install xcpretty
-        run: gem install xcpretty
-
-      - name: Restore Pods cache
-        uses: actions/cache@v4
-        with:
-          path: example/ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
-      - name: Install Pods
-        working-directory: example/ios
-        run: pod install
-      - name: Build App
-        working-directory: example/ios
-        run: "set -o pipefail && xcodebuild \
-          CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \
-          -derivedDataPath build -UseModernBuildSystem=YES \
-          -workspace $$exampleApp$$.xcworkspace \
-          -scheme $$exampleApp$$ \
-          -sdk iphonesimulator \
-          -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 16' \
-          build \
-          CODE_SIGNING_ALLOWED=NO | xcpretty"
-
-  build_old:
-    name: Build iOS Example App (old architecture)
-    runs-on: macOS-15
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 16.4
-
-      - name: Install npm dependencies (bun)
+      - name: Install dependencies (bun)
         run: bun install
 
       - name: Disable new architecture in Podfile
+        if: matrix.arch == 'old'
         run: sed -i "" "s/ENV\['RCT_NEW_ARCH_ENABLED'\] = '1'/ENV['RCT_NEW_ARCH_ENABLED'] = '0'/g" example/ios/Podfile
-
-      - name: Restore buildcache
-        uses: mikehardy/buildcache-action@v2
-        continue-on-error: true
 
       - name: Setup Ruby (bundle)
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: '3.2'
           bundler-cache: true
           working-directory: example/ios
 
       - name: Install xcpretty
         run: gem install xcpretty
 
-      - name: Restore Pods cache
+      - name: Cache CocoaPods
         uses: actions/cache@v4
         with:
-          path: example/ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock', '**/Gemfile.lock') }}
+          path: |
+            ~/.cocoapods/repos
+            example/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('example/ios/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
+
       - name: Install Pods
         working-directory: example/ios
         run: pod install
+
       - name: Build App
         working-directory: example/ios
-        run: "set -o pipefail && xcodebuild \
-          CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \
-          -derivedDataPath build -UseModernBuildSystem=YES \
-          -workspace $$exampleApp$$.xcworkspace \
-          -scheme $$exampleApp$$ \
-          -sdk iphonesimulator \
-          -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 16' \
-          build \
-          CODE_SIGNING_ALLOWED=NO | xcpretty"
+        run: |
+          set -o pipefail && xcodebuild \
+            CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \
+            -derivedDataPath build -UseModernBuildSystem=YES \
+            -workspace $$exampleApp$$.xcworkspace \
+            -scheme $$exampleApp$$ \
+            -sdk iphonesimulator \
+            -configuration Debug \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            build \
+            CODE_SIGNING_ALLOWED=NO | xcpretty

--- a/scripts/e2e-maestro.sh
+++ b/scripts/e2e-maestro.sh
@@ -64,9 +64,17 @@ if [ "$PLATFORM" == "ios" ]; then
   # Check if xcpretty is available
   if command -v xcpretty >/dev/null 2>&1; then
     set -o pipefail && $buildCmd | xcpretty
+    if [ $? -ne 0 ]; then
+      echo "❌ iOS build failed!"
+      exit 1
+    fi
   else
     echo "⚠️  xcpretty not found. Install with: gem install xcpretty"
     $buildCmd
+    if [ $? -ne 0 ]; then
+      echo "❌ iOS build failed!"
+      exit 1
+    fi
   fi
   
   # Launch the simulator if not already booted
@@ -92,6 +100,10 @@ else
   # Build with optimizations and pretty output
   echo "🔨 Building Android app..."
   ./gradlew assembleRelease --no-daemon --build-cache --parallel --console=rich
+  if [ $? -ne 0 ]; then
+    echo "❌ Android build failed!"
+    exit 1
+  fi
   APK_PATH="app/build/outputs/apk/release/app-release.apk"
   
   # Install the APK


### PR DESCRIPTION
This refactors the Android and iOS template workflows for clarity, speed, and consistency.

Android
- consolidate duplicate jobs into a matrix (new/old)
- add Gradle cache and use setup-java v5
- keep Bun install; disable new arch for old via sed

iOS
- consolidate duplicate jobs into a matrix (new/old)
- add CocoaPods caches (repos + Pods)
- move to Ruby 3.2; keep Bun install
- add workflow_dispatch trigger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Manual triggers for iOS/Android build workflows
  - Matrix-driven builds for new/old architectures
  - Integrated codegen and upstream artifact download/listing

- Bug Fixes
  - Early failure detection with clear iOS/Android build error messages in E2E script

- Chores
  - Tightened workflow permissions (read-only)
  - Added Xcode 16.4 setup for iOS E2E
  - Switched to Yarn-only; updated Ruby to 3.2 and JDK setup
  - Enabled CocoaPods/Gradle caching for faster builds
  - Updated runners/conditions and consolidated workflow steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->