### PR TITLE
chore(android): enable RN_SERIALIZABLE_STATE for Nitro Views

### DIFF
--- a/assets/template/android/CMakeLists.txt
+++ b/assets/template/android/CMakeLists.txt
@@ -5,6 +5,9 @@ set (PACKAGE_NAME $$androidCxxLibName$$)
 set (CMAKE_VERBOSE_MAKEFILE ON)
 set (CMAKE_CXX_STANDARD 20)
 
+# Enable Raw Props parsing in react-native (for Nitro Views)
+add_compile_options(-DRN_SERIALIZABLE_STATE=1)
+
 # Define C++ library and add all sources
 add_library(${PACKAGE_NAME} SHARED
         src/main/cpp/cpp-adapter.cpp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build configuration to enhance state serialization support, improving reliability of advanced views.
  * Improves compatibility and stability for Android builds with no changes required from users.
  * No UI or behavioral changes expected; background enhancement to ensure smoother operation on Android.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->