### PR TITLE
fix(android): prevent Nitro View crash by enabling RN_SERIALIZABLE_STATE

### DIFF
--- a/assets/template/android/CMakeLists.txt
+++ b/assets/template/android/CMakeLists.txt
@@ -5,6 +5,9 @@ set (PACKAGE_NAME $$androidCxxLibName$$)
 set (CMAKE_VERBOSE_MAKEFILE ON)
 set (CMAKE_CXX_STANDARD 20)
 
+# Enable Raw Props parsing in react-native (for Nitro Views)
+add_compile_options(-DRN_SERIALIZABLE_STATE=1)
+
 # Define C++ library and add all sources
 add_library(${PACKAGE_NAME} SHARED
         src/main/cpp/cpp-adapter.cpp


### PR DESCRIPTION
Android Nitro View could crash because Raw Props parsing wasn’t enabled.

- Problem: Nitro View on Android would crash when RN parsed props without serializable state support.
- Cause: `RN_SERIALIZABLE_STATE` wasn’t defined in the Android template’s CMake configuration, leading to mismatches with React Native’s Raw Props handling.
- Fix: Enable Raw Props parsing by adding `add_compile_options(-DRN_SERIALIZABLE_STATE=1)` in `assets/template/android/CMakeLists.txt:1`.
- Scope: Template-only change; affects Android builds of Nitro modules generated from this template.
- Risk: Low. This aligns compile-time flags with React Native expectations and prevents crashes.

Please review and merge to unblock Android consumers.