### PR TITLE
fix: skip postcodegen when kotlin is enabled

### DIFF
--- a/assets/template/package.json
+++ b/assets/template/package.json
@@ -56,7 +56,7 @@
     "@types/react": "19.1.0",
     "nitrogen": "^0.29.4",
     "react": "19.1.0",
-    "react-native": "0.81.4",
+    "react-native": "0.81.1",
     "react-native-builder-bob": "^0.37.0",
     "react-native-nitro-modules": "^0.2942",
     "conventional-changelog-conventionalcommits": "^9.1.0",

--- a/assets/template/package.json
+++ b/assets/template/package.json
@@ -56,7 +56,7 @@
     "@types/react": "19.1.0",
     "nitrogen": "^0.29.4",
     "react": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.4",
     "react-native-builder-bob": "^0.37.0",
     "react-native-nitro-modules": "^0.2942",
     "conventional-changelog-conventionalcommits": "^9.1.0",

--- a/src/generate-nitro-package.ts
+++ b/src/generate-nitro-package.ts
@@ -181,7 +181,9 @@ export class NitroModuleFactory {
             ...newWorkspacePackageJsonFile.scripts,
             build: `${this.config.pm} run typecheck && bob build`,
             codegen: `nitrogen --logLevel="debug" && ${this.config.pm} run build${this.config.langs.includes(SupportedLang.KOTLIN) ? ' && node post-script.js' : ''}`,
-            postcodegen: this.getPostCodegenScript(),
+            postcodegen: !this.config.langs.includes(SupportedLang.KOTLIN)
+                ? this.getPostCodegenScript()
+                : undefined,
         }
 
         // Resolve and pin latest Nitro tools to concrete versions


### PR DESCRIPTION
## Summary
- skip adding the example postcodegen script when Kotlin support is selected so the Kotlin post-script can run instead
- bump the example template to react-native 0.81.4 to align with the latest published version

## Testing
- not run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the React Native dev dependency in the template to 0.81.4, bringing in the latest stability and compatibility improvements.

* **Build**
  * Optimized code generation handling: Kotlin-based projects now automatically skip an unnecessary post-codegen step, while non-Kotlin projects retain existing behavior. This reduces redundant work and can speed up builds with no change to project setup for other configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->