### PR TITLE
fix(ci): fix iOS harness action version and app path

### DIFF
--- a/e2e/harness-workflows.test.ts
+++ b/e2e/harness-workflows.test.ts
@@ -145,7 +145,7 @@ const assertHarnessWorkflowContent = async (
     expect(androidWorkflow).toContain('chmod +x ./gradlew')
     expect(androidWorkflow).toContain('projectRoot: example')
     expect(iosWorkflow).toContain(
-        'uses: callstackincubator/react-native-harness@v1.0.0'
+        'uses: callstackincubator/react-native-harness@v1.2.0'
     )
     expect(iosWorkflow).toContain('projectRoot: example')
     expect(androidWorkflow).toContain(expectation.harnessWorkflowPath)

--- a/src/code-snippets/code.js.ts
+++ b/src/code-snippets/code.js.ts
@@ -445,9 +445,9 @@ ${getHarnessCodegenBuildStep(packageManager, monorepo)}
             CODE_SIGNING_ALLOWED=NO
 
       - name: Run React Native Harness
-        uses: callstackincubator/react-native-harness@v1.0.0
+        uses: callstackincubator/react-native-harness@v1.2.0
         with:
-          app: example/ios/build/Build/Products/Debug-iphonesimulator/${exampleAppName}.app
+          app: ios/build/Build/Products/Debug-iphonesimulator/${exampleAppName}.app
           runner: ios
           projectRoot: example
           packageManager: ${packageManager}`


### PR DESCRIPTION
The generated \`harness-ios.yml\` has two bugs that break iOS CI on every new module:

**Bug 1 — wrong harness action version**
Uses \`callstackincubator/react-native-harness@v1.0.0\` which has no \`action.yml\` and fails immediately. The Android workflow already uses \`v1.2.0\`.

**Bug 2 — wrong \`app:\` path**
The \`app:\` path includes the \`example/\` prefix, but since \`projectRoot: example\` is set, paths are already resolved relative to \`example/\`. This produces a doubled prefix (\`example/example/ios/...\`) and the app bundle is never found. The Android workflow already uses the correct convention (\`android/app/build/...\` relative to \`projectRoot\`).

## Fix

- Bump iOS harness action to \`v1.2.0\` (same as Android)
- Change \`app:\` from \`example/ios/build/...\` to \`ios/build/...\`

Both changes are in \`src/code-snippets/code.js.ts\`, inside \`getHarnessJobCode()\`.

## Tested on

Verified by running the fixed workflow on a generated module, iOS harness now boots the simulator and runs tests successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the iOS build workflow to use a newer supported setup, improving compatibility and reducing build issues.
  * Corrected the app path used by the workflow so iOS jobs point to the right project location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->